### PR TITLE
update property `usWidthClass` property for Condensed fonts

### DIFF
--- a/scripts/instantiate_condensed.py
+++ b/scripts/instantiate_condensed.py
@@ -11,7 +11,7 @@ from scripts import (
 
 
 roman_instance = {
-    "attribs": {"usWidthClass": 5},
+    "attribs": {"usWidthClass": 3},
     "axes": {"wdth": 75},
     "filename": "RobotoCondensed[wght].ttf",
     "names": {
@@ -25,7 +25,7 @@ roman_instance = {
 }
 
 italic_instance = {
-    "attribs": {"usWidthClass": 5, "italicAngle": -12, "caretSlopeRise": 2048, "caretSlopeRun": 435},
+    "attribs": {"usWidthClass": 3, "italicAngle": -12, "caretSlopeRise": 2048, "caretSlopeRun": 435},
     "axes": {"wdth": 75},
     "filename": "RobotoCondensed-Italic[wght].ttf",
     "names": {

--- a/scripts/instantiate_statics.py
+++ b/scripts/instantiate_statics.py
@@ -54,7 +54,7 @@ instances = [
         },
     },
     {
-        "attribs": {"fsSelection": 64, "macStyle": 0, "usWeightClass": 300, "usWidthClass": 5},
+        "attribs": {"fsSelection": 64, "macStyle": 0, "usWeightClass": 300, "usWidthClass": 3},
         "axes": {"ital": 0.0, "wdth": 75.0, "wght": 300},
         "filename": "RobotoCondensed-Light.ttf",
         "names": {
@@ -68,7 +68,7 @@ instances = [
         },
     },
     {
-        "attribs": {"fsSelection": 513, "macStyle": 2, "usWeightClass": 300, "italicAngle": -12, "usWidthClass": 5, "caretSlopeRise": 2048, "caretSlopeRun": 435},
+        "attribs": {"fsSelection": 513, "macStyle": 2, "usWeightClass": 300, "italicAngle": -12, "usWidthClass": 3, "caretSlopeRise": 2048, "caretSlopeRun": 435},
         "axes": {"ital": 1.0, "wdth": 75.0, "wght": 300},
         "filename": "RobotoCondensed-LightItalic.ttf",
         "names": {
@@ -108,7 +108,7 @@ instances = [
         },
     },
     {
-            "attribs": {"fsSelection": 64, "macStyle": 0, "usWeightClass": 400, "usWidthClass": 5},
+            "attribs": {"fsSelection": 64, "macStyle": 0, "usWeightClass": 400, "usWidthClass": 3},
         "axes": {"ital": 0.0, "wdth": 75.0, "wght": 400},
         "filename": "RobotoCondensed-Regular.ttf",
         "names": {
@@ -120,7 +120,7 @@ instances = [
         },
     },
     {
-        "attribs": {"fsSelection": 513, "macStyle": 2, "usWeightClass": 400, "italicAngle": -12, "usWidthClass": 5, "caretSlopeRise": 2048, "caretSlopeRun": 435},
+        "attribs": {"fsSelection": 513, "macStyle": 2, "usWeightClass": 400, "italicAngle": -12, "usWidthClass": 3, "caretSlopeRise": 2048, "caretSlopeRun": 435},
         "axes": {"ital": 1.0, "wdth": 75.0, "wght": 400},
         "filename": "RobotoCondensed-Italic.ttf",
         "names": {
@@ -144,7 +144,7 @@ instances = [
         },
     },
     {
-        "attribs": {"fsSelection": 64, "macStyle": 0, "usWeightClass": 500, "usWidthClass": 5},
+        "attribs": {"fsSelection": 64, "macStyle": 0, "usWeightClass": 500, "usWidthClass": 3},
         "axes": {"ital": 0.0, "wdth": 75.0, "wght": 500},
         "filename": "RobotoCondensed-Medium.ttf",
         "names": {
@@ -172,7 +172,7 @@ instances = [
         },
     },
     {
-        "attribs": {"fsSelection": 513, "macStyle": 2, "usWeightClass": 500, "italicAngle": -12, "usWidthClass": 5, "caretSlopeRise": 2048, "caretSlopeRun": 435},
+        "attribs": {"fsSelection": 513, "macStyle": 2, "usWeightClass": 500, "italicAngle": -12, "usWidthClass": 3, "caretSlopeRise": 2048, "caretSlopeRun": 435},
         "axes": {"ital": 1.0, "wdth": 75.0, "wght": 500},
         "filename": "RobotoCondensed-MediumItalic.ttf",
         "names": {
@@ -200,7 +200,7 @@ instances = [
         },
     },
     {
-        "attribs": {"fsSelection": 32, "macStyle": 1, "usWeightClass": 700, "usWidthClass": 5},
+        "attribs": {"fsSelection": 32, "macStyle": 1, "usWeightClass": 700, "usWidthClass": 3},
         "axes": {"ital": 0.0, "wdth": 75.0, "wght": 700},
         "filename": "RobotoCondensed-Bold.ttf",
         "names": {
@@ -224,7 +224,7 @@ instances = [
         },
     },
     {
-        "attribs": {"fsSelection": 545, "macStyle": 3, "usWeightClass": 700, "italicAngle": -12, "usWidthClass": 5, "caretSlopeRise": 2048, "caretSlopeRun": 435},
+        "attribs": {"fsSelection": 545, "macStyle": 3, "usWeightClass": 700, "italicAngle": -12, "usWidthClass": 3, "caretSlopeRise": 2048, "caretSlopeRun": 435},
         "axes": {"ital": 1.0, "wdth": 75.0, "wght": 700},
         "filename": "RobotoCondensed-BoldItalic.ttf",
         "names": {
@@ -289,4 +289,3 @@ for inst in instances:
     del instance['STAT']
     out_path = os.path.join(sys.argv[2], inst["filename"])
     instance.save(out_path)
-

--- a/sources/RobotoCondensed-Bold.ufo/fontinfo.plist
+++ b/sources/RobotoCondensed-Bold.ufo/fontinfo.plist
@@ -309,7 +309,7 @@
     <key>openTypeOS2WeightClass</key>
     <integer>700</integer>
     <key>openTypeOS2WidthClass</key>
-    <integer>5</integer>
+    <integer>3</integer>
     <key>openTypeOS2WinAscent</key>
     <integer>2146</integer>
     <key>openTypeOS2WinDescent</key>

--- a/sources/RobotoCondensed-BoldItalic.ufo/fontinfo.plist
+++ b/sources/RobotoCondensed-BoldItalic.ufo/fontinfo.plist
@@ -311,7 +311,7 @@
     <key>openTypeOS2WeightClass</key>
     <integer>700</integer>
     <key>openTypeOS2WidthClass</key>
-    <integer>5</integer>
+    <integer>3</integer>
     <key>openTypeOS2WinAscent</key>
     <integer>2146</integer>
     <key>openTypeOS2WinDescent</key>

--- a/sources/RobotoCondensed-Italic.ufo/fontinfo.plist
+++ b/sources/RobotoCondensed-Italic.ufo/fontinfo.plist
@@ -311,7 +311,7 @@
     <key>openTypeOS2WeightClass</key>
     <integer>400</integer>
     <key>openTypeOS2WidthClass</key>
-    <integer>5</integer>
+    <integer>3</integer>
     <key>openTypeOS2WinAscent</key>
     <integer>2146</integer>
     <key>openTypeOS2WinDescent</key>

--- a/sources/RobotoCondensed-Light.ufo/fontinfo.plist
+++ b/sources/RobotoCondensed-Light.ufo/fontinfo.plist
@@ -313,7 +313,7 @@
     <key>openTypeOS2WeightClass</key>
     <integer>300</integer>
     <key>openTypeOS2WidthClass</key>
-    <integer>5</integer>
+    <integer>3</integer>
     <key>openTypeOS2WinAscent</key>
     <integer>2146</integer>
     <key>openTypeOS2WinDescent</key>

--- a/sources/RobotoCondensed-LightItalic.ufo/fontinfo.plist
+++ b/sources/RobotoCondensed-LightItalic.ufo/fontinfo.plist
@@ -315,7 +315,7 @@
     <key>openTypeOS2WeightClass</key>
     <integer>300</integer>
     <key>openTypeOS2WidthClass</key>
-    <integer>5</integer>
+    <integer>3</integer>
     <key>openTypeOS2WinAscent</key>
     <integer>2146</integer>
     <key>openTypeOS2WinDescent</key>

--- a/sources/RobotoCondensed-Regular.ufo/fontinfo.plist
+++ b/sources/RobotoCondensed-Regular.ufo/fontinfo.plist
@@ -309,7 +309,7 @@
     <key>openTypeOS2WeightClass</key>
     <integer>400</integer>
     <key>openTypeOS2WidthClass</key>
-    <integer>5</integer>
+    <integer>3</integer>
     <key>openTypeOS2WinAscent</key>
     <integer>2146</integer>
     <key>openTypeOS2WinDescent</key>


### PR DESCRIPTION
Fix: https://github.com/googlefonts/roboto-3-classic/issues/130
Related: https://github.com/typst/typst/issues/2098